### PR TITLE
Upgrade to .NET 9.0 and update dependencies

### DIFF
--- a/.github/workflows/buildwindowsimage.yml
+++ b/.github/workflows/buildwindowsimage.yml
@@ -14,6 +14,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2.3.4
+  
+    - name: Install NET 9
+      uses: actions/setup-dotnet@v4.0.1
+      with:
+        dotnet-version: '9.0.x'
 
     - name: Get the version
       id: get_version

--- a/.github/workflows/createrelease.yml
+++ b/.github/workflows/createrelease.yml
@@ -15,6 +15,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2.3.4
 
+    - name: Install NET 9
+      uses: actions/setup-dotnet@v4.0.1
+      with:
+        dotnet-version: '9.0.x'  
+
     - name: Get the version
       id: get_version
       run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -16,6 +16,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2.3.4
 
+    - name: Install NET 9
+      uses: actions/setup-dotnet@v4.0.1
+      with:
+        dotnet-version: '9.0.x'
+        
     - name: Restore Nuget Packages
       run: dotnet restore TestHosts/TestHosts.sln --source ${{ secrets.PUBLICFEEDURL }} --source ${{ secrets.PRIVATEFEED_URL }}
 

--- a/.github/workflows/pushtomaster.yml
+++ b/.github/workflows/pushtomaster.yml
@@ -19,6 +19,11 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: Install NET 9
+      uses: actions/setup-dotnet@v4.0.1
+      with:
+        dotnet-version: '9.0.x'
+
     - name: Restore Nuget Packages
       run: dotnet restore TestHosts/TestHosts.sln --source ${{ secrets.PUBLICFEEDURL }} --source ${{ secrets.PRIVATEFEED_URL }}
 

--- a/TestHosts/TestHosts/Dockerfile
+++ b/TestHosts/TestHosts/Dockerfile
@@ -1,7 +1,7 @@
 FROM stuartferguson/txnprocbase:latest AS base
 WORKDIR /app
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 WORKDIR /src
 COPY ["TestHosts/TestHosts.csproj", "TestHosts/"]
 COPY ["TestHosts/NuGet.Config", "TestHosts/"]

--- a/TestHosts/TestHosts/Dockerfilewindows
+++ b/TestHosts/TestHosts/Dockerfilewindows
@@ -2,7 +2,7 @@ FROM stuartferguson/txnprocbasewindows AS base
 USER ContainerAdministrator
 WORKDIR /app
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0-windowsservercore-ltsc2022 AS build
+FROM mcr.microsoft.com/dotnet/sdk:9.0-windowsservercore-ltsc2022 AS build
 WORKDIR /src
 COPY ["TestHosts/TestHosts.csproj", "TestHosts/"]
 COPY ["TestHosts/NuGet.Config", "TestHosts/"]

--- a/TestHosts/TestHosts/TestHosts.csproj
+++ b/TestHosts/TestHosts/TestHosts.csproj
@@ -1,34 +1,34 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-	  <TargetFramework>net8.0</TargetFramework>
+	  <TargetFramework>net9.0</TargetFramework>
     <UserSecretsId>96de5658-e1fb-40f6-99ed-4203c8807474</UserSecretsId>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
   </PropertyGroup>
 
   <ItemGroup>
-	  <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="8.0.2" />
-	  <PackageReference Include="AspNetCore.HealthChecks.UI" Version="8.0.2" />
-	  <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="8.0.1" />
-	  <PackageReference Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="8.0.1" />
-	  <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="8.0.1" />
+	  <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="9.0.0" />
+	  <PackageReference Include="AspNetCore.HealthChecks.UI" Version="9.0.0" />
+	  <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
+	  <PackageReference Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="9.0.0" />
+	  <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="9.0.0" />
 	  <PackageReference Include="CoreWCF.Http" Version="1.7.0" />
     <PackageReference Include="CoreWCF.Primitives" Version="1.7.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.14" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.14" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.14" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.14" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="8.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="9.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="9.0.5" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.2" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.7" />
-    <PackageReference Include="Shared" Version="2025.3.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.3.1" />
-    <PackageReference Include="NLog.Extensions.Logging" Version="5.4.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.14">
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="9.0.0" />
+    <PackageReference Include="Shared" Version="2025.6.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.2" />
+    <PackageReference Include="NLog.Extensions.Logging" Version="5.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.14">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.5">
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
This commit upgrades the .NET version from 8.0 to 9.0 across multiple files, including YAML configuration files for CI/CD pipelines and the Dockerfile. The `buildwindowsimage.yml`, `createrelease.yml`, and `pushtomaster.yml` files now include steps to install .NET 9.0. The `Dockerfile` and `Dockerfilewindows` have been modified to use the .NET 9.0 SDK. Additionally, the `TestHosts.csproj` file has been updated to target .NET 9.0 and includes updated package references for several dependencies to their latest versions compatible with .NET 9.0.

Closes #52 