### PR TITLE
Remove duplicate bill check TODO comment

### DIFF
--- a/TestHosts/TestHosts/Controllers/DeveloperController.cs
+++ b/TestHosts/TestHosts/Controllers/DeveloperController.cs
@@ -104,9 +104,7 @@ namespace TestHosts.Controllers
             using ResolvedDbContext<PataPawaContext>? resolvedContext = this.ContextResolver.Resolve(PataPawaReadModelKey);
 
             Guid billIdentifier = Guid.NewGuid();
-
-            // TODO: check for a duplicate bill??
-
+            
             await resolvedContext.Context.PostPaidBills.AddAsync(new PostPaidBill {
                                                                 Amount = request.Amount,
                                                                 AccountNumber = request.AccountNumber,


### PR DESCRIPTION
The "// TODO: check for a duplicate bill??" comment was removed from DeveloperController.cs. No functional changes were made.

closes #116 
closes #128 