### PR TITLE
Refactor: centralize config keys in Constants class

### DIFF
--- a/TestHosts/TestHosts/Controllers/DeveloperController.cs
+++ b/TestHosts/TestHosts/Controllers/DeveloperController.cs
@@ -18,7 +18,7 @@ namespace TestHosts.Controllers
     public class DeveloperController : ControllerBase
     {
         private readonly IDbContextResolver<PataPawaContext> ContextResolver;
-        private const String PataPawaReadModelKey = "PataPawaReadModel";
+        
         public DeveloperController(IDbContextResolver<PataPawaContext> contextResolver) {
             this.ContextResolver = contextResolver;
         }
@@ -27,7 +27,7 @@ namespace TestHosts.Controllers
         [Route("patapawaprepay/createuser")]
         public async Task<IActionResult> CreatePrepayUser([FromBody] CreatePatapawaPrePayUser request, CancellationToken cancellationToken){
             
-            using ResolvedDbContext<PataPawaContext>? resolvedContext = this.ContextResolver.Resolve(PataPawaReadModelKey);
+            using ResolvedDbContext<PataPawaContext>? resolvedContext = this.ContextResolver.Resolve(Constants.PataPawaReadModelConfig);
 
             Guid userId = Guid.NewGuid();
 
@@ -57,7 +57,7 @@ namespace TestHosts.Controllers
         [Route("patapawaprepay/adduserdebt")]
         public async Task<IActionResult> AddUserDebt([FromBody] AddPatapawaPrePayUserDebt request, CancellationToken cancellationToken)
         {
-            using ResolvedDbContext<PataPawaContext>? resolvedContext = this.ContextResolver.Resolve(PataPawaReadModelKey);
+            using ResolvedDbContext<PataPawaContext>? resolvedContext = this.ContextResolver.Resolve(Constants.PataPawaReadModelConfig);
             
             PrePayUser user = await resolvedContext.Context.PrePayUsers.SingleOrDefaultAsync(u => u.UserName == request.UserName, cancellationToken);
 
@@ -75,7 +75,7 @@ namespace TestHosts.Controllers
         [HttpPost]
         [Route("patapawaprepay/createmeter")]
         public async Task<IActionResult> CreatePrepayMeter([FromBody] CreatePatapawaPrePayMeter request, CancellationToken cancellationToken){
-            using ResolvedDbContext<PataPawaContext>? resolvedContext = this.ContextResolver.Resolve(PataPawaReadModelKey);
+            using ResolvedDbContext<PataPawaContext>? resolvedContext = this.ContextResolver.Resolve(Constants.PataPawaReadModelConfig);
             
             Guid meterId = Guid.NewGuid();
 
@@ -101,7 +101,7 @@ namespace TestHosts.Controllers
         public async Task<IActionResult> CreateHostConfiguration([FromBody] CreatePataPawaPostPayBill request,
                                                                  CancellationToken cancellationToken)
         {
-            using ResolvedDbContext<PataPawaContext>? resolvedContext = this.ContextResolver.Resolve(PataPawaReadModelKey);
+            using ResolvedDbContext<PataPawaContext>? resolvedContext = this.ContextResolver.Resolve(Constants.PataPawaReadModelConfig);
 
             Guid billIdentifier = Guid.NewGuid();
             

--- a/TestHosts/TestHosts/Database/PataPawa/PataPawaContext.cs
+++ b/TestHosts/TestHosts/Database/PataPawa/PataPawaContext.cs
@@ -9,13 +9,12 @@ namespace TestHosts.Database.PataPawa
     public class PataPawaContext : DbContext
     {
         private readonly String ConnectionString;
-        private const String PataPawaReadModelKey = "PataPawaReadModel";
         public PataPawaContext()
         {
             // This is the migration connection string
 
             // Get connection string from configuration.
-            this.ConnectionString = ConfigurationReader.GetConnectionString(PataPawaReadModelKey);
+            this.ConnectionString = ConfigurationReader.GetConnectionString(Constants.PataPawaReadModelConfig);
         }
 
         public PataPawaContext(String connectionString)

--- a/TestHosts/TestHosts/Program.cs
+++ b/TestHosts/TestHosts/Program.cs
@@ -101,7 +101,7 @@ try {
         options.SerializerSettings.ContractResolver = new CamelCasePropertyNamesContractResolver();
     });
     builder.Services.AddHealthChecks().AddSqlServer(connectionString: ConfigurationReader.GetConnectionString("HealthCheck"), healthQuery: "SELECT 1;", name: "Read Model Server", failureStatus: HealthStatus.Degraded, tags: new[] { "db", "sql", "sqlserver" });
-    ;
+    
     builder.Services.AddServiceModelServices().AddServiceModelMetadata();
 
     builder.Services.AddSingleton(typeof(IDbContextResolver<>), typeof(DbContextResolver<>));
@@ -206,6 +206,6 @@ finally {
 
 
 public static class Constants {
-    public const String PataPawaReadModelConfig = "PataPawaReadModel";
-    public const String TestBankReadModelConfig = "TestBankReadModel";
+    public static readonly String PataPawaReadModelConfig = "PataPawaReadModel";
+    public static readonly String TestBankReadModelConfig = "TestBankReadModel";
 }

--- a/TestHosts/TestHosts/Program.cs
+++ b/TestHosts/TestHosts/Program.cs
@@ -1,164 +1,150 @@
 
-    using CoreWCF;
-    using CoreWCF.Configuration;
-    using CoreWCF.Description;
-    using HealthChecks.UI.Client;
-    using Microsoft.AspNetCore.Builder;
-    using Microsoft.AspNetCore.Diagnostics.HealthChecks;
-    using Microsoft.AspNetCore.Hosting;
-    using Microsoft.Extensions.Configuration;
-    using Microsoft.Extensions.DependencyInjection;
-    using Microsoft.Extensions.Diagnostics.HealthChecks;
-    using Microsoft.Extensions.Hosting;
-    using Microsoft.Extensions.Hosting.WindowsServices;
-    using Microsoft.Extensions.Logging;
-    using NLog;
-    using NLog.Web;
-    using Shared.EntityFramework;
-    using Shared.Extensions;
-    using Shared.General;
-    using Shared.Middleware;
-    using System;
-    using System.IO;
-    using System.Reflection;
-    using System.Security;
-    using Microsoft.EntityFrameworkCore;
-    using Newtonsoft.Json;
-    using Newtonsoft.Json.Serialization;
-    using Sentry.Extensibility;
-    using Shared.Logger.TennantContext;
-    using TestHosts;
-    using TestHosts.Common;
-    using TestHosts.Database.PataPawa;
-    using TestHosts.Database.TestBank;
-    using TestHosts.SoapServices;
-    using LogLevel = Microsoft.Extensions.Logging.LogLevel;
+using CoreWCF;
+using CoreWCF.Configuration;
+using CoreWCF.Description;
+using HealthChecks.UI.Client;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Hosting.WindowsServices;
+using Microsoft.Extensions.Logging;
+using NLog;
+using NLog.Web;
+using Shared.EntityFramework;
+using Shared.Extensions;
+using Shared.General;
+using Shared.Middleware;
+using System;
+using System.IO;
+using System.Reflection;
+using System.Security;
+using Microsoft.EntityFrameworkCore;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using Sentry.Extensibility;
+using Shared.Logger.TennantContext;
+using TestHosts;
+using TestHosts.Common;
+using TestHosts.Database.PataPawa;
+using TestHosts.Database.TestBank;
+using TestHosts.SoapServices;
+using ILogger = Microsoft.Extensions.Logging.ILogger;
+using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
-    const String PataPawaReadModelKey = "PataPawaReadModel";
-    const String TestBankReadModelKey = "TestBankReadModel";
+
 try {
 
-        WebApplicationBuilder builder = WebApplication.CreateBuilder(new WebApplicationOptions { Args = args, ContentRootPath = AppContext.BaseDirectory });
-        
-        // ----------------------------------------------------------------------
-        // Load custom hosting configuration (your existing hosting.json setup)
-        // ----------------------------------------------------------------------
-        FileInfo fi = new FileInfo(System.Reflection.Assembly.GetExecutingAssembly().Location);
-        builder.Configuration.SetBasePath(fi.Directory!.FullName).AddJsonFile("hosting.json", optional: false, reloadOnChange: true).AddJsonFile("hosting.development.json", optional: true, reloadOnChange: true)
-            .AddJsonFile("/home/txnproc/config/appsettings.json", true, true)
-            .AddJsonFile($"/home/txnproc/config/appsettings.{builder.Environment.EnvironmentName}.json", optional: true)
-            .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
-            .AddJsonFile($"appsettings.{builder.Environment.EnvironmentName}.json", optional: true, reloadOnChange: true)
-            .AddEnvironmentVariables();
+    WebApplicationBuilder builder = WebApplication.CreateBuilder(new WebApplicationOptions { Args = args, ContentRootPath = AppContext.BaseDirectory });
 
-        ConfigurationReader.Initialise(builder.Configuration);
-        // ----------------------------------------------------------------------
-        // Configure Windows Service mode
-        // ----------------------------------------------------------------------
-        if (WindowsServiceHelpers.IsWindowsService())
-            builder.Host.UseWindowsService();
+    // ----------------------------------------------------------------------
+    // Load custom hosting configuration (your existing hosting.json setup)
+    // ----------------------------------------------------------------------
+    FileInfo fi = new FileInfo(System.Reflection.Assembly.GetExecutingAssembly().Location);
+    builder.Configuration.SetBasePath(fi.Directory!.FullName).AddJsonFile("hosting.json", optional: false, reloadOnChange: true).AddJsonFile("hosting.development.json", optional: true, reloadOnChange: true).AddJsonFile("/home/txnproc/config/appsettings.json", true, true).AddJsonFile($"/home/txnproc/config/appsettings.{builder.Environment.EnvironmentName}.json", optional: true).AddJsonFile("appsettings.json", optional: true, reloadOnChange: true).AddJsonFile($"appsettings.{builder.Environment.EnvironmentName}.json", optional: true, reloadOnChange: true).AddEnvironmentVariables();
 
-        // ----------------------------------------------------------------------
-        // Configure Kestrel
-        // ----------------------------------------------------------------------
-        builder.WebHost.ConfigureKestrel(options => { options.AllowSynchronousIO = true; });
+    ConfigurationReader.Initialise(builder.Configuration);
+    // ----------------------------------------------------------------------
+    // Configure Windows Service mode
+    // ----------------------------------------------------------------------
+    if (WindowsServiceHelpers.IsWindowsService())
+        builder.Host.UseWindowsService();
+
+    // ----------------------------------------------------------------------
+    // Configure Kestrel
+    // ----------------------------------------------------------------------
+    builder.WebHost.ConfigureKestrel(options => { options.AllowSynchronousIO = true; });
 
     // ----------------------------------------------------------------------
     // Configure Sentry
     // ----------------------------------------------------------------------
     var sentrySection = ConfigurationReader.GetValueOrDefault("SentryConfiguration", "Dsn", "N/A");
-        if (sentrySection != "N/A")
-        {
-            // Replace the condition below if you intended to only enable Sentry in certain environments.
-            if (builder.Environment.IsDevelopment() == false)
-            {
-                builder.WebHost.UseSentry(o =>
-                {
-                    o.Dsn = sentrySection;
-                    o.SendDefaultPii = true;
-                    o.MaxRequestBodySize = RequestSize.Always;
-                    o.CaptureBlockingCalls = ConfigurationReader.GetValueOrDefault("SentryConfiguration", "CaptureBlockingCalls", false);
-                    o.IncludeActivityData = ConfigurationReader.GetValueOrDefault("SentryConfiguration", "IncludeActivityData", false);
-                    o.Release = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "unknown";
-                });
-            }
+    if (sentrySection != "N/A") {
+        // Replace the condition below if you intended to only enable Sentry in certain environments.
+        if (builder.Environment.IsDevelopment() == false) {
+            builder.WebHost.UseSentry(o => {
+                o.Dsn = sentrySection;
+                o.SendDefaultPii = true;
+                o.MaxRequestBodySize = RequestSize.Always;
+                o.CaptureBlockingCalls = ConfigurationReader.GetValueOrDefault("SentryConfiguration", "CaptureBlockingCalls", false);
+                o.IncludeActivityData = ConfigurationReader.GetValueOrDefault("SentryConfiguration", "IncludeActivityData", false);
+                o.Release = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "unknown";
+            });
         }
+    }
 
     // ----------------------------------------------------------------------
     // Configure NLog
     // ----------------------------------------------------------------------
     string nlogConfigFilename = "nlog.config";
-        if (builder.Environment.IsDevelopment()) {
-            String devFile = Path.Combine(builder.Environment.ContentRootPath, "nlog.development.config");
-            if (File.Exists(devFile))
-                nlogConfigFilename = "nlog.development.config";
-        }
+    if (builder.Environment.IsDevelopment()) {
+        String devFile = Path.Combine(builder.Environment.ContentRootPath, "nlog.development.config");
+        if (File.Exists(devFile))
+            nlogConfigFilename = "nlog.development.config";
+    }
 
-        LogManager.Setup().LoadConfigurationFromFile(Path.Combine(builder.Environment.ContentRootPath, nlogConfigFilename));
-        builder.Logging.ClearProviders();
-        builder.Host.UseNLog();
+    LogManager.Setup().LoadConfigurationFromFile(Path.Combine(builder.Environment.ContentRootPath, nlogConfigFilename));
+    builder.Logging.ClearProviders();
+    builder.Host.UseNLog();
 
-// ----------------------------------------------------------------------
-// Add application and framework services
-// ----------------------------------------------------------------------
-        builder.Services.AddControllers().AddNewtonsoftJson(options =>
-        {
-            options.SerializerSettings.ReferenceLoopHandling = ReferenceLoopHandling.Ignore;
-            options.SerializerSettings.TypeNameHandling = TypeNameHandling.None;
-            options.SerializerSettings.Formatting = Formatting.Indented;
-            options.SerializerSettings.DateTimeZoneHandling = DateTimeZoneHandling.Utc;
-            options.SerializerSettings.ContractResolver = new CamelCasePropertyNamesContractResolver();
-        });
-    builder.Services.AddHealthChecks().AddSqlServer(connectionString: ConfigurationReader.GetConnectionString("HealthCheck"),
-            healthQuery: "SELECT 1;",
-            name: "Read Model Server",
-            failureStatus: HealthStatus.Degraded,
-            tags: new[] { "db", "sql", "sqlserver" }); ;
-        builder.Services.AddServiceModelServices().AddServiceModelMetadata();
+    // ----------------------------------------------------------------------
+    // Add application and framework services
+    // ----------------------------------------------------------------------
+    builder.Services.AddControllers().AddNewtonsoftJson(options => {
+        options.SerializerSettings.ReferenceLoopHandling = ReferenceLoopHandling.Ignore;
+        options.SerializerSettings.TypeNameHandling = TypeNameHandling.None;
+        options.SerializerSettings.Formatting = Formatting.Indented;
+        options.SerializerSettings.DateTimeZoneHandling = DateTimeZoneHandling.Utc;
+        options.SerializerSettings.ContractResolver = new CamelCasePropertyNamesContractResolver();
+    });
+    builder.Services.AddHealthChecks().AddSqlServer(connectionString: ConfigurationReader.GetConnectionString("HealthCheck"), healthQuery: "SELECT 1;", name: "Read Model Server", failureStatus: HealthStatus.Degraded, tags: new[] { "db", "sql", "sqlserver" });
+    ;
+    builder.Services.AddServiceModelServices().AddServiceModelMetadata();
 
-        builder.Services.AddSingleton(typeof(IDbContextResolver<>), typeof(DbContextResolver<>));
-        if (builder.Environment.IsEnvironment("IntegrationTest") || builder.Configuration.GetValue<Boolean>("ServiceOptions:UseInMemoryDatabase") == true)
-        {
-            builder.Services.AddDbContext<TestBankContext>(builder => builder.UseInMemoryDatabase(TestBankReadModelKey));
-            builder.Services.AddDbContext<PataPawaContext>(builder => builder.UseInMemoryDatabase(PataPawaReadModelKey));
+    builder.Services.AddSingleton(typeof(IDbContextResolver<>), typeof(DbContextResolver<>));
+    if (builder.Environment.IsEnvironment("IntegrationTest") || builder.Configuration.GetValue<Boolean>("ServiceOptions:UseInMemoryDatabase") == true) {
+        builder.Services.AddDbContext<TestBankContext>(builder => builder.UseInMemoryDatabase(Constants.TestBankReadModelConfig));
+        builder.Services.AddDbContext<PataPawaContext>(builder => builder.UseInMemoryDatabase(Constants.PataPawaReadModelConfig));
 
-        }
-        else
-        {
-            String testBankConnectionString = ConfigurationReader.GetConnectionString(TestBankReadModelKey);
-            builder.Services.AddDbContext<TestBankContext>(builder => builder.UseSqlServer(testBankConnectionString));
+    }
+    else {
+        String testBankConnectionString = ConfigurationReader.GetConnectionString(Constants.TestBankReadModelConfig);
+        builder.Services.AddDbContext<TestBankContext>(builder => builder.UseSqlServer(testBankConnectionString));
 
-            String pataPawaConnectionString = ConfigurationReader.GetConnectionString(PataPawaReadModelKey);
-            builder.Services.AddDbContext<PataPawaContext>(builder => builder.UseSqlServer(pataPawaConnectionString));
-        }
-        builder.Services.AddScoped<TenantContext>(x => new TenantContext());
-        builder.Services.AddSingleton<PataPawaPostPayService>();
+        String pataPawaConnectionString = ConfigurationReader.GetConnectionString(Constants.PataPawaReadModelConfig);
+        builder.Services.AddDbContext<PataPawaContext>(builder => builder.UseSqlServer(pataPawaConnectionString));
+    }
+
+    builder.Services.AddScoped<TenantContext>(x => new TenantContext());
+    builder.Services.AddSingleton<PataPawaPostPayService>();
     // Add your background hosted service
     builder.Services.AddHostedService<PendingPrePaymentProcessor>(provider => {
-            IDbContextResolver<PataPawaContext> contextResolver = provider.GetRequiredService<IDbContextResolver<PataPawaContext>>();
-            return new PendingPrePaymentProcessor(contextResolver);
-        });
+        IDbContextResolver<PataPawaContext> contextResolver = provider.GetRequiredService<IDbContextResolver<PataPawaContext>>();
+        return new PendingPrePaymentProcessor(contextResolver);
+    });
 
-// Database initialization will now be handled by a hosted service
-        builder.Services.AddHostedService<DatabaseInitializerHostedService>();
+    // Database initialization will now be handled by a hosted service
+    builder.Services.AddHostedService<DatabaseInitializerHostedService>();
 
-        builder.Services.AddScoped<TenantContext>(x => new TenantContext());
-        builder.Services.AddSingleton<PataPawaPostPayService>();
-        builder.Services.AddMvc();
+    builder.Services.AddScoped<TenantContext>(x => new TenantContext());
+    builder.Services.AddSingleton<PataPawaPostPayService>();
+    builder.Services.AddMvc();
 
-        builder.Services.AddServiceModelServices().AddServiceModelMetadata();
-        builder.Services.AddSingleton<IServiceBehavior, UseRequestHeadersForMetadataAddressBehavior>();
-        builder.Services.AddSingleton<IServiceBehavior, CorrelationIdBehavior>();
+    builder.Services.AddServiceModelServices().AddServiceModelMetadata();
+    builder.Services.AddSingleton<IServiceBehavior, UseRequestHeadersForMetadataAddressBehavior>();
+    builder.Services.AddSingleton<IServiceBehavior, CorrelationIdBehavior>();
 
 
-        bool logRequests = ConfigurationReader.GetValueOrDefault<Boolean>("MiddlewareLogging", "LogRequests", true);
-        bool logResponses = ConfigurationReader.GetValueOrDefault<Boolean>("MiddlewareLogging", "LogResponses", true);
-        LogLevel middlewareLogLevel = ConfigurationReader.GetValueOrDefault<LogLevel>("MiddlewareLogging", "MiddlewareLogLevel", LogLevel.Warning);
+    bool logRequests = ConfigurationReader.GetValueOrDefault<Boolean>("MiddlewareLogging", "LogRequests", true);
+    bool logResponses = ConfigurationReader.GetValueOrDefault<Boolean>("MiddlewareLogging", "LogResponses", true);
+    LogLevel middlewareLogLevel = ConfigurationReader.GetValueOrDefault<LogLevel>("MiddlewareLogging", "MiddlewareLogLevel", LogLevel.Warning);
 
-        RequestResponseMiddlewareLoggingConfig config =
-            new RequestResponseMiddlewareLoggingConfig(middlewareLogLevel, logRequests, logResponses);
+    RequestResponseMiddlewareLoggingConfig config = new RequestResponseMiddlewareLoggingConfig(middlewareLogLevel, logRequests, logResponses);
 
-        builder.Services.AddSingleton(config);
+    builder.Services.AddSingleton(config);
 
     // ----------------------------------------------------------------------
     // Build the app
@@ -166,55 +152,60 @@ try {
     WebApplication app = builder.Build();
 
     // Create a scoped logger and assign it
-     using (var scope = app.Services.CreateScope())
-     {
-         var loggerFactory = scope.ServiceProvider.GetRequiredService<ILoggerFactory>();
-         var loggerObject = loggerFactory.CreateLogger("AppStartup");
-         Shared.Logger.Logger.Initialise(loggerObject);
-     }
+    using (IServiceScope scope = app.Services.CreateScope()) {
+        ILoggerFactory loggerFactory = scope.ServiceProvider.GetRequiredService<ILoggerFactory>();
+        ILogger loggerObject = loggerFactory.CreateLogger("AppStartup");
+        Shared.Logger.Logger.Initialise(loggerObject);
+    }
 
-// ----------------------------------------------------------------------
-// Middleware pipeline
-// ----------------------------------------------------------------------
-        if (app.Environment.IsDevelopment()) {
-            app.UseDeveloperExceptionPage();
-        }
+    // ----------------------------------------------------------------------
+    // Middleware pipeline
+    // ----------------------------------------------------------------------
+    if (app.Environment.IsDevelopment()) {
+        app.UseDeveloperExceptionPage();
+    }
 
-// Custom middleware
-        app.UseMiddleware<TenantMiddleware>();
-        app.AddRequestResponseLogging();
-        app.AddExceptionHandler();
+    // Custom middleware
+    app.UseMiddleware<TenantMiddleware>();
+    app.AddRequestResponseLogging();
+    app.AddExceptionHandler();
 
-        app.UseRouting();
+    app.UseRouting();
 
-// ----------------------------------------------------------------------
-// Endpoints
-// ----------------------------------------------------------------------
-        app.MapControllers();
+    // ----------------------------------------------------------------------
+    // Endpoints
+    // ----------------------------------------------------------------------
+    app.MapControllers();
 
-        app.MapHealthChecks("health", new HealthCheckOptions { Predicate = _ => true, ResponseWriter = Shared.HealthChecks.HealthCheckMiddleware.WriteResponse });
+    app.MapHealthChecks("health", new HealthCheckOptions { Predicate = _ => true, ResponseWriter = Shared.HealthChecks.HealthCheckMiddleware.WriteResponse });
 
-        app.MapHealthChecks("healthui", new HealthCheckOptions { Predicate = _ => true, ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse });
+    app.MapHealthChecks("healthui", new HealthCheckOptions { Predicate = _ => true, ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse });
 
-// ----------------------------------------------------------------------
-// CoreWCF setup
-// ----------------------------------------------------------------------
-        app.UseServiceModel(builder => { builder.AddService<PataPawaPostPayService>(options => { options.DebugBehavior.IncludeExceptionDetailInFaults = true; }).AddServiceEndpoint<PataPawaPostPayService, IPataPawaPostPayService>(new BasicHttpBinding(), "/PataPawaPostPayService/basichttp"); });
+    // ----------------------------------------------------------------------
+    // CoreWCF setup
+    // ----------------------------------------------------------------------
+    app.UseServiceModel(builder => { builder.AddService<PataPawaPostPayService>(options => { options.DebugBehavior.IncludeExceptionDetailInFaults = true; }).AddServiceEndpoint<PataPawaPostPayService, IPataPawaPostPayService>(new BasicHttpBinding(), "/PataPawaPostPayService/basichttp"); });
 
-        ServiceMetadataBehavior metadataBehavior = app.Services.GetRequiredService<ServiceMetadataBehavior>();
-        metadataBehavior.HttpGetEnabled = true;
+    ServiceMetadataBehavior metadataBehavior = app.Services.GetRequiredService<ServiceMetadataBehavior>();
+    metadataBehavior.HttpGetEnabled = true;
 
-// ----------------------------------------------------------------------
-// Start the application
-// ----------------------------------------------------------------------
-        app.Run();
+    // ----------------------------------------------------------------------
+    // Start the application
+    // ----------------------------------------------------------------------
+    app.Run();
 
-        Shared.Logger.Logger.LogWarning("Application started successfully");
+    Shared.Logger.Logger.LogWarning("Application started successfully");
 }
-    catch (Exception ex) {
-        Shared.Logger.Logger.LogError("Application stopped due to exception", ex);
-        throw;
-    }
-    finally {
-        LogManager.Shutdown();
-    }
+catch (Exception ex) {
+    Shared.Logger.Logger.LogError("Application stopped due to exception", ex);
+    throw;
+}
+finally {
+    LogManager.Shutdown();
+}
+
+
+public static class Constants {
+    public const String PataPawaReadModelConfig = "PataPawaReadModel";
+    public const String TestBankReadModelConfig = "TestBankReadModel";
+}

--- a/TestHosts/TestHosts/SoapServices/PataPawaPostPayService.cs
+++ b/TestHosts/TestHosts/SoapServices/PataPawaPostPayService.cs
@@ -12,7 +12,7 @@ using DataTransferObjects;
 public class PataPawaPostPayService : IPataPawaPostPayService
 {
     private readonly IDbContextResolver<PataPawaContext> ContextResolver;
-    private const String PataPawaReadModelKey = "PataPawaReadModel";
+    
     #region Constructors
 
     public PataPawaPostPayService(IDbContextResolver<PataPawaContext> contextResolver) {
@@ -26,7 +26,7 @@ public class PataPawaPostPayService : IPataPawaPostPayService
     public LoginResponse Login(String username,
                                String password) {
         // Check if we have an api key
-        using ResolvedDbContext<PataPawaContext>? resolvedContext = this.ContextResolver.Resolve(PataPawaReadModelKey);
+        using ResolvedDbContext<PataPawaContext>? resolvedContext = this.ContextResolver.Resolve(Constants.PataPawaReadModelConfig);
         PostPaidAccount account = PataPawaPostPayService.GetPostPaidAccount(username, resolvedContext.Context);
 
         if (account == null) {
@@ -67,7 +67,7 @@ public class PataPawaPostPayService : IPataPawaPostPayService
                                            String mobile_no,
                                            String customer_name,
                                            Decimal amount) {
-        using ResolvedDbContext<PataPawaContext>? resolvedContext = this.ContextResolver.Resolve(PataPawaReadModelKey);
+        using ResolvedDbContext<PataPawaContext>? resolvedContext = this.ContextResolver.Resolve(Constants.PataPawaReadModelConfig);
         PostPaidAccount account = GetAccount(username, api_key, resolvedContext.Context);
         if (account == null) {
             return new ProcessBillResponse {
@@ -102,7 +102,7 @@ public class PataPawaPostPayService : IPataPawaPostPayService
     public VerifyResponse VerifyAccount(String username,
                                         String api_key,
                                         String account_no) {
-        using ResolvedDbContext<PataPawaContext>? resolvedContext = this.ContextResolver.Resolve(PataPawaReadModelKey);
+        using ResolvedDbContext<PataPawaContext>? resolvedContext = this.ContextResolver.Resolve(Constants.PataPawaReadModelConfig);
         PostPaidAccount account = PataPawaPostPayService.GetAccount(username, api_key, resolvedContext.Context);
             if (account == null) {
                 return new VerifyResponse {


### PR DESCRIPTION
Replaced hardcoded DB config keys with Constants.PataPawaReadModelConfig and Constants.TestBankReadModelConfig throughout the codebase. Refactored Program.cs for clarity and maintainability, updating configuration, service registration, and middleware setup to use the new constants. Removed obsolete string constants. No functional changes; improves maintainability and reduces risk of typos.

closes #143 