### PR TITLE
Centralize NuGet package version management

### DIFF
--- a/TestHosts/Directory.Build.props
+++ b/TestHosts/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+  <PropertyGroup>
+	<!-- Enable centralized package management -->
+	<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+	<!-- Ensure SDK-style projects restore correctly -->
+	<RestoreProjectStyle>PackageReference</RestoreProjectStyle>
+  </PropertyGroup>
+</Project>

--- a/TestHosts/Directory.Packages.props
+++ b/TestHosts/Directory.Packages.props
@@ -1,0 +1,39 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="AspNetCore.HealthChecks.SqlServer" Version="9.0.0" />
+    <PackageVersion Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
+    <PackageVersion Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="9.0.0" />
+    <PackageVersion Include="AspNetCore.HealthChecks.Uris" Version="9.0.0" />
+    <PackageVersion Include="CoreWCF.Http" Version="1.9.0" />
+    <PackageVersion Include="CoreWCF.Primitives" Version="1.9.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
+    <PackageVersion Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="10.0.2" />
+    <PackageVersion Include="NLog.Web.AspNetCore" Version="6.1.3" />
+    <PackageVersion Include="NuGet.Packaging" Version="7.6.0" />
+    <PackageVersion Include="NuGet.Protocol" Version="7.6.0" />
+    <PackageVersion Include="Sentry.AspNetCore" Version="6.6.0" />
+    <PackageVersion Include="Shared" Version="2026.5.7" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.1" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9" />
+    <PackageVersion Include="ClientProxyBase" Version="2026.5.7" />
+    <PackageVersion Include="Shared.Results" Version="2026.5.7" />
+    <PackageVersion Include="Shared.IntegrationTesting" Version="2026.5.7" />
+    <PackageVersion Include="NUnit" Version="4.6.1" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
+    <PackageVersion Include="Reqnroll.NUnit" Version="3.3.4" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageVersion Include="Reqnroll" Version="3.3.4" />
+    <PackageVersion Include="Reqnroll.Tools.MsBuild.Generation" Version="3.3.4" />
+    <PackageVersion Include="Shouldly" Version="4.3.0" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
+  </ItemGroup>
+</Project>

--- a/TestHosts/TestHosts.Clients/TestHosts.Clients.csproj
+++ b/TestHosts/TestHosts.Clients/TestHosts.Clients.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="ClientProxyBase" Version="2026.5.7" />
-		<PackageReference Include="Shared.Results" Version="2026.5.7" />
+		<PackageReference Include="ClientProxyBase" />
+		<PackageReference Include="Shared.Results" />
 	</ItemGroup>
 	<ItemGroup>
 	  <ProjectReference Include="..\TestHosts.DataTransferObjects\TestHosts.DataTransferObjects.csproj" />

--- a/TestHosts/TestHosts.IntegrationTests/TestHosts.IntegrationTests.csproj
+++ b/TestHosts/TestHosts.IntegrationTests/TestHosts.IntegrationTests.csproj
@@ -7,15 +7,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-	  <PackageReference Include="Shared.IntegrationTesting" Version="2026.5.5" />
-	  <PackageReference Include="NUnit" Version="4.5.1" />
-	  <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
-	  <PackageReference Include="Reqnroll.NUnit" Version="3.3.3" />
-	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-	  <PackageReference Include="Reqnroll" Version="3.3.3" />
-	  <PackageReference Include="Reqnroll.Tools.MsBuild.Generation" Version="3.3.3" />
-	  <PackageReference Include="Shouldly" Version="4.3.0" />
-	  <PackageReference Include="coverlet.collector" Version="8.0.0">
+	  <PackageReference Include="Shared.IntegrationTesting" />
+	  <PackageReference Include="NUnit" />
+	  <PackageReference Include="NUnit3TestAdapter" />
+	  <PackageReference Include="Reqnroll.NUnit" />
+	  <PackageReference Include="Microsoft.NET.Test.Sdk" />
+	  <PackageReference Include="Reqnroll" />
+	  <PackageReference Include="Reqnroll.Tools.MsBuild.Generation" />
+	  <PackageReference Include="Shouldly" />
+	  <PackageReference Include="coverlet.collector">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>

--- a/TestHosts/TestHosts.sln
+++ b/TestHosts/TestHosts.sln
@@ -11,6 +11,15 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestHosts.DataTransferObjec
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestHosts.Clients", "TestHosts.Clients\TestHosts.Clients.csproj", "{4E96C5C3-9ABD-44B6-9047-64A78BF40B09}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{50B827EF-9E58-48D0-9CD9-6F32B2DF236A}"
+	ProjectSection(SolutionItems) = preProject
+		Directory.Packages.props = Directory.Packages.props
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{EE95A101-2EFF-4E8E-A603-1587901B6319}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{208122B0-E9C8-402B-AAA0-354082F8058E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -36,6 +45,12 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{2AA295CE-3480-4206-A4AE-47112F00BF8F} = {EE95A101-2EFF-4E8E-A603-1587901B6319}
+		{E242FAB3-8F81-43E4-B76A-654F876DB840} = {208122B0-E9C8-402B-AAA0-354082F8058E}
+		{EF0A5414-7D16-486A-A042-790C6768B7F4} = {EE95A101-2EFF-4E8E-A603-1587901B6319}
+		{4E96C5C3-9ABD-44B6-9047-64A78BF40B09} = {EE95A101-2EFF-4E8E-A603-1587901B6319}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B1819E4D-394A-48C4-B9EC-1E7D0B0D4764}

--- a/TestHosts/TestHosts/Dockerfile
+++ b/TestHosts/TestHosts/Dockerfile
@@ -5,6 +5,8 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 COPY ["TestHosts/TestHosts.csproj", "TestHosts/"]
 COPY ["TestHosts/NuGet.Config", "TestHosts/"]
+COPY ["Directory.Packages.props", "."]
+COPY . .
 RUN dotnet restore "TestHosts/TestHosts.csproj"
 COPY . .
 WORKDIR "/src/TestHosts"

--- a/TestHosts/TestHosts/Dockerfilewindows
+++ b/TestHosts/TestHosts/Dockerfilewindows
@@ -6,6 +6,8 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0-windowsservercore-ltsc2022 AS build
 WORKDIR /src
 COPY ["TestHosts/TestHosts.csproj", "TestHosts/"]
 COPY ["TestHosts/NuGet.Config", "TestHosts/"]
+COPY ["Directory.Packages.props", "."]
+COPY . .
 RUN dotnet restore "TestHosts/TestHosts.csproj"
 COPY . .
 WORKDIR "/src/TestHosts"

--- a/TestHosts/TestHosts/TestHosts.csproj
+++ b/TestHosts/TestHosts/TestHosts.csproj
@@ -11,31 +11,31 @@
   </ItemGroup>
 
   <ItemGroup>
-	  <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="9.0.0" />
-	  <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
-	  <PackageReference Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="9.0.0" />
-	  <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="9.0.0" />
-	  <PackageReference Include="CoreWCF.Http" Version="1.8.0" />
-    <PackageReference Include="CoreWCF.Primitives" Version="1.8.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.5" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="10.0.2" />
-    <PackageReference Include="NLog.Web.AspNetCore" Version="6.1.2" />
-    <PackageReference Include="NuGet.Packaging" Version="7.6.0" />
-    <PackageReference Include="NuGet.Protocol" Version="7.6.0" />
-    <PackageReference Include="Sentry.AspNetCore" Version="6.2.0" />
-    <PackageReference Include="Shared" Version="2026.3.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.5" />
-    
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.5">
+    <PackageReference Include="AspNetCore.HealthChecks.SqlServer" />
+    <PackageReference Include="AspNetCore.HealthChecks.UI.Client" />
+    <PackageReference Include="AspNetCore.HealthChecks.UI.InMemory.Storage" />
+    <PackageReference Include="AspNetCore.HealthChecks.Uris" />
+    <PackageReference Include="CoreWCF.Http" />
+    <PackageReference Include="CoreWCF.Primitives" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" />
+    <PackageReference Include="NLog.Web.AspNetCore" />
+    <PackageReference Include="NuGet.Packaging" />
+    <PackageReference Include="NuGet.Protocol" />
+    <PackageReference Include="Sentry.AspNetCore" />
+    <PackageReference Include="Shared" />
+    <PackageReference Include="Swashbuckle.AspNetCore" />
+
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/TestHosts/WebApplication1/WebApplication1.csproj
+++ b/TestHosts/WebApplication1/WebApplication1.csproj
@@ -6,6 +6,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="SoapCore" Version="1.1.0.31" />
+		<PackageReference Include="SoapCore" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
Adopt Directory.Packages.props and Directory.Build.props for centralized package versioning. Remove explicit version numbers from project files and update the solution structure to include solution folders and the new props file. This streamlines dependency management and simplifies future updates.

closes #165 